### PR TITLE
Added optional 'verbose' query param to api/account/:addr endpoint for detailed tx history

### DIFF
--- a/backend/db/aerospike-client.js
+++ b/backend/db/aerospike-client.js
@@ -37,6 +37,12 @@ exports.get = function(set, pk, policy, callback) {
   var key = new Aerospike.Key(ns, set, pk);
   client.get(key, policy, callback);
 }
+exports.batchGet = function(set, pkArr, policy, callback) {
+  var keys = pkArr.map(function (pk) {
+    return new Aerospike.Key(ns, set, pk)
+  });
+  client.batchGet(keys, policy, callback);
+}
 exports.exists = function(set, pk, policy, callback){
   var key = new Aerospike.Key(ns, set, pk);
   client.exists(key, policy, callback);

--- a/backend/explorer-api/run.js
+++ b/backend/explorer-api/run.js
@@ -96,7 +96,7 @@ function main() {
       // transactions router       
       transactionsRouter(app, transactionDao, progressDao, config);
       // account router
-      accountRouter(app, accountDao, config);
+      accountRouter(app, accountDao, transactionDao, config);
       // keep push block data
       // pushTopBlocks();
     }


### PR DESCRIPTION
![screen shot 2018-06-30 at 6 49 01 pm](https://user-images.githubusercontent.com/994683/42130326-4c164a4c-7c96-11e8-9b25-7eda5e459564.png)

Added `?verbose=true` query param to `api/account/:addr` endpoint. This runs a 
[batchGet](https://github.com/aerospike/aerospike-client-nodejs/blob/master/docs/client.md#batchGet) in aerospike on the `txs_hash_list` output of the existing result, and normalizes the records the same way as performed when displaying output from `api/transaction/:txhash`.

This will be needed by future Theta wallet implementations and can be adapted to the explorer, in order to display a detailed transaction history with respect to an account--displaying just a list of hashes is not very informative IMO. Happy to refactor/rearrange to a different endpoint should alternate architectural decisions warrant it.

@jieyilong It'd be great if you could review this (I can't assign a reviewer). Also please let me know what is welcome and what is not with regards to open source contributions to thetatoken repos. I don't want to step on any toes or derail a private roadmap.