### PR TITLE
Allow to choose between HTTP and HTTPS during deployment time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ desktop.ini
 **/*.log
 **/.DS_Store
 node_modules/*
+**/.idea

--- a/backend/explorer-api/run.js
+++ b/backend/explorer-api/run.js
@@ -174,8 +174,8 @@ function main() {
           console.log("HTTP rest API running on port ", config.server.port)
         })
       }
-
       
+
       // REST services
       // blocks router
       blocksRouter(app, blockDao, progressDao, checkpointDao, config);

--- a/backend/mongo-db/mongo-client.js
+++ b/backend/mongo-db/mongo-client.js
@@ -22,7 +22,7 @@ exports.init = function (execDir, hostIp, hostPort, dbName) {
 exports.connect = function (uri, callback) {
   if (_db) return callback();
   url = uri ? uri : url;
-  console.log(`url is: `, url);
+//  console.log(`url is: `, url); # Removed line so it doesnt expose the the mongodb uri
   MongoClient.connect(url, {
     useNewUrlParser: true,
     autoReconnect: true,


### PR DESCRIPTION
Most of the modern software stack doesn't handle HTTPS/SSL on the application side but rather on the proxy/gateway level as most likely the application itself won't even be exposed to the internet. 
With that in mind, most people won't benefit from the existing HTTP2/HTTPS implementation currently in place using the SPDY protocol.

This PR aims to use the already existing config param in order to allow the explorer API to be exposed as plain HTTP using the already existing express instance of the application.

Please, if there are any guidelines on contributions for this project and this PR somehow hurt any of them, let me know and I'll be more than happy to accomodate the changes in my PR.

Also, if this doesn't make sense at all, I'd like to hear the reasoning behind it =) 

Thanks.