### PR TITLE
Allow setting a custom request timeout

### DIFF
--- a/backend/crawler/api/rpc.js
+++ b/backend/crawler/api/rpc.js
@@ -166,7 +166,7 @@ var processHttpRequest = function (host, port, method, path, requestBody, callba
       });
     });
 
-    const timeout = config.request_timeout_ms || 10000
+    const timeout = config.requestTimeoutMs || 10000
     req.setTimeout(timeout, function () {
       req.abort();
       callback('Request Timeout: ' + path, null);

--- a/backend/crawler/api/rpc.js
+++ b/backend/crawler/api/rpc.js
@@ -166,7 +166,8 @@ var processHttpRequest = function (host, port, method, path, requestBody, callba
       });
     });
 
-    req.setTimeout(10000, function () {
+    const timeout = config.request_timeout_ms || 10000
+    req.setTimeout(timeout, function () {
       req.abort();
       callback('Request Timeout: ' + path, null);
       callback = null;


### PR DESCRIPTION
Recently I had an issue where a particular request was taking longer than 10s (i.e. the default timeout), it'd be nice to have a way to configure timeout through the config file.

Since a lot of people might be running their coin-node under a variety of different hardware, with various different API req loads, the crawler could suffer because of this